### PR TITLE
Fix deprecated container

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { initializeStore } from '../app/store'
 import { Provider } from 'react-redux'
-import App, { Container, AppContext } from 'next/app'
+import App, { AppContext } from 'next/app'
 import withRedux from 'next-redux-wrapper'
 import { Store } from 'redux'
 import { loadUserFromLocalStorage } from '../app/session/storage'
@@ -38,14 +38,12 @@ class MyApp extends App<{ store: Store }> {
     const { Component, pageProps, store } = this.props
 
     return (
-      <Container>
-        <Provider store={store}>
-          <AppEffects />
-          <Layout>
-            <Component {...pageProps} />
-          </Layout>
-        </Provider>
-      </Container>
+      <Provider store={store}>
+        <AppEffects />
+        <Layout>
+          <Component {...pageProps} />
+        </Layout>
+      </Provider>
     )
   }
 }


### PR DESCRIPTION
## Why

```
Warning: the `Container` in `_app` has been deprecated and should be removed. https://err.sh/zeit/next.js/app-container-deprecated
```

## What

Follow the instructions mentioned in the error and remove the `Container` wrapper component.