### PR TITLE
Smarter display name validation rules

### DIFF
--- a/src/app/session/components/forms/RegisterForm.tsx
+++ b/src/app/session/components/forms/RegisterForm.tsx
@@ -38,11 +38,6 @@ const RegisterForm = ({
   const [submitting, setSubmitting] = useState(false)
   const [error, setError] = useState(undefined as string | undefined)
 
-  const validate = () =>
-    validateEmail(email) &&
-    validatePassword(password) &&
-    validateDisplayName(displayName)
-
   const submit = async (event: FormEvent) => {
     event.preventDefault()
 
@@ -65,6 +60,11 @@ const RegisterForm = ({
       complete()
     }
   }
+
+  const validate = () =>
+    validateEmail(email) &&
+    validatePassword(password) &&
+    validateDisplayName(displayName)
 
   const hasError = {
     form: !validate(),
@@ -100,7 +100,7 @@ const RegisterForm = ({
             error={hasError.displayName}
           />
           <GroupError
-            message="Display name should be at least 2 characters"
+            message="Should be between 2-18 letters or numbers"
             hidden={!hasError.displayName}
           />
         </Label>

--- a/src/app/session/domain.spec.ts
+++ b/src/app/session/domain.spec.ts
@@ -11,9 +11,9 @@ describe('validateDisplayName', () => {
     expect(valid).toBeTruthy()
   })
 
-  it('should disallow spaces', () => {
+  it('should allow spaces', () => {
     const valid = validateDisplayName('foo bar')
-    expect(valid).toBeFalsy()
+    expect(valid).toBeTruthy()
   })
 
   it('should disallow 1 character names', () => {

--- a/src/app/session/domain.spec.ts
+++ b/src/app/session/domain.spec.ts
@@ -1,0 +1,33 @@
+import { validateDisplayName } from './domain'
+
+describe('validateDisplayName', () => {
+  it('should allow a correct value', () => {
+    const valid = validateDisplayName('foo-bar_123')
+    expect(valid).toBeTruthy()
+  })
+
+  it('should allow unicode', () => {
+    const valid = validateDisplayName('神様')
+    expect(valid).toBeTruthy()
+  })
+
+  it('should disallow spaces', () => {
+    const valid = validateDisplayName('foo bar')
+    expect(valid).toBeFalsy()
+  })
+
+  it('should disallow 1 character names', () => {
+    const valid = validateDisplayName('a')
+    expect(valid).toBeFalsy()
+  })
+
+  it('should disallow names that are too long', () => {
+    const valid = validateDisplayName('abcdefghijklmnopqwrstuvw')
+    expect(valid).toBeFalsy()
+  })
+
+  it('should disallow names with strange characters', () => {
+    const valid = validateDisplayName("Robert'); DROP TABLE students;--")
+    expect(valid).toBeFalsy()
+  })
+})

--- a/src/app/session/domain.ts
+++ b/src/app/session/domain.ts
@@ -5,6 +5,6 @@ export const validatePassword = (password: string): boolean =>
   password != '' && password.length >= 6
 
 export const validateDisplayName = (name: string): boolean =>
-  /^([\p{Alphabetic}\p{Mark}\p{Decimal_Number}\p{Connector_Punctuation}\p{Join_Control}_-]{2,18})$/u.exec(
+  /^([\p{Alphabetic}\p{Mark}\p{Decimal_Number}\p{Connector_Punctuation}\p{Join_Control} _-]{2,18})$/u.exec(
     name,
   ) !== null

--- a/src/app/session/domain.ts
+++ b/src/app/session/domain.ts
@@ -5,4 +5,6 @@ export const validatePassword = (password: string): boolean =>
   password != '' && password.length >= 6
 
 export const validateDisplayName = (name: string): boolean =>
-  name != '' && name.length >= 2
+  /^([\p{Alphabetic}\p{Mark}\p{Decimal_Number}\p{Connector_Punctuation}\p{Join_Control}_-]{2,18})$/u.exec(
+    name,
+  ) !== null

--- a/src/app/user/components/forms/ProfileForm.tsx
+++ b/src/app/user/components/forms/ProfileForm.tsx
@@ -38,8 +38,6 @@ const ProfileForm = ({ user, setUser, userLoaded }: Props) => {
     return null
   }
 
-  const validate = () => validateDisplayName(displayName)
-
   const submit = async (event: FormEvent) => {
     event.preventDefault()
 
@@ -66,6 +64,8 @@ const ProfileForm = ({ user, setUser, userLoaded }: Props) => {
     }
   }
 
+  const validate = () => validateDisplayName(displayName)
+
   const hasError = {
     form: !validate(),
     displayName: displayName != '' && !validateDisplayName(displayName),
@@ -85,7 +85,7 @@ const ProfileForm = ({ user, setUser, userLoaded }: Props) => {
             error={hasError.displayName}
           />
           <GroupError
-            message="Display name should be at least 2 characters"
+            message="Should be between 2-18 letters or numbers"
             hidden={!hasError.displayName}
           />
         </Label>


### PR DESCRIPTION
## Why

So far we only checked if it was 2 characters or longer

## What

* [x] [Implement same validation rules as on the server side ](https://github.com/tadoku/api/pull/116)
* [x] Update error labels in forms that check on display name