### PR TITLE
Fix storybook

### DIFF
--- a/.storybook/config.tsx
+++ b/.storybook/config.tsx
@@ -1,10 +1,10 @@
 import React from 'react'
 import { configure } from '@storybook/react'
 import { addDecorator } from '@storybook/react'
-import { GlobalStyle } from '../app/ui/components/Layout'
-import Constants from '../app/ui/Constants'
+import { GlobalStyle } from '../src/app/ui/components/Layout'
+import Constants from '../src/app/ui/Constants'
 
-const req = require.context('../app', true, /.stories.tsx$/)
+const req = require.context('../src/app', true, /.stories.tsx$/)
 function loadStories() {
   req.keys().forEach(filename => req(filename))
 }

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "@storybook/react": "^5.2.8",
     "@types/jest": "^24.0.25",
     "@types/node": "^13.1.1",
-    "@types/storybook__react": "^4.0.2",
     "@typescript-eslint/eslint-plugin": "^1.13.0",
     "@typescript-eslint/parser": "^1.13.0",
     "@zeit/next-css": "^1.0.1",

--- a/src/app/ui/components/Footer.stories.tsx
+++ b/src/app/ui/components/Footer.stories.tsx
@@ -2,4 +2,8 @@ import React from 'react'
 import { storiesOf } from '@storybook/react'
 import Footer from './Footer'
 
-storiesOf('Footer', module).add('default', () => <Footer />)
+storiesOf('Footer', module).add('default', () => (
+  <div style={{ height: '300px', width: '100%', position: 'relative' }}>
+    <Footer />
+  </div>
+))


### PR DESCRIPTION
## Why

> Dependabot can't resolve your JavaScript dependency files.
> 
> As a result, Dependabot couldn't update your dependencies.
> 
> The error Dependabot encountered was:
> 
> ```Error whilst updating @types/storybook__react in /yarn.lock:
> Couldn't find package "storybook__react@*" required by "@types/storybook__react@5.2.0" on the "npm" registry.
>```
> If you think the above is an error on Dependabot's side please don't hesitate to get in touch - we'll do whatever we can to fix it.

## What

So there were several issues with the storybook implementation:

* [x] Remove deprecated `@types/storybook__react` package
* [x] Fix relative import path in the storybook config
* [x] Put the `Footer` component in a container that is visible in its story