### PR TITLE
Remove hardcoded contest ids

### DIFF
--- a/src/app/ranking/components/List.tsx
+++ b/src/app/ranking/components/List.tsx
@@ -39,8 +39,8 @@ export default RankingList
 // @TODO: make sure the contest id is given with the ranking
 const RankingRow = ({ rank, tied, data }: RankingWithRank) => (
   <Row>
-    <Link href={`/contest-profile/3/${data.userId}`}>
-      <RowLink href={`/contest-profile/3/${data.userId}`}>
+    <Link href={`/contest-profile/${data.contestId}/${data.userId}`}>
+      <RowLink href={`/contest-profile/${data.contestId}/${data.userId}`}>
         <Rank>
           {tied && <span title="Tied">T</span>}
           {rank}


### PR DESCRIPTION
## Why

The links in the ranking list still used hardcoded contest ids because the backend didn't expose them.

## What

The backend now exposes the contest ids, so I made the frontend use them.