### PR TITLE
Fix dynamic routed links

### DIFF
--- a/src/app/ranking/components/List.tsx
+++ b/src/app/ranking/components/List.tsx
@@ -36,11 +36,13 @@ const RankingList = (props: Props) => {
 
 export default RankingList
 
-// @TODO: make sure the contest id is given with the ranking
 const RankingRow = ({ rank, tied, data }: RankingWithRank) => (
   <Row>
-    <Link href={`/contest-profile/${data.contestId}/${data.userId}`}>
-      <RowLink href={`/contest-profile/${data.contestId}/${data.userId}`}>
+    <Link
+      href="/contest-profile/[contest_id]/[user_id]"
+      as={`/contest-profile/${data.contestId}/${data.userId}`}
+    >
+      <RowLink href="">
         <Rank>
           {tied && <span title="Tied">T</span>}
           {rank}

--- a/src/app/session/components/navigation/UserMenu.tsx
+++ b/src/app/session/components/navigation/UserMenu.tsx
@@ -13,7 +13,7 @@ interface Props {
 const UserProfile = ({ user }: Props) => (
   <Dropdown label={user.displayName}>
     <DropdownItem>
-      <Link href={`/settings/${SettingsTab.Profile}`}>
+      <Link href="/settings/[tab]" as={`/settings/${SettingsTab.Profile}`}>
         {/* TODO: Remove span once https://github.com/zeit/next.js/issues/7915 is fixed */}
         <span>
           <Button plain icon="cog">

--- a/src/app/user/components/SettingsSidebar.tsx
+++ b/src/app/user/components/SettingsSidebar.tsx
@@ -62,7 +62,7 @@ const SettingsLink = ({
   label: string
 }) => (
   <SettingsItem active={activeTab === tab}>
-    <Link as={`/settings/${tab}`} href={`/settings?tab=${tab}`}>
+    <Link as={`/settings/${tab}`} href={`/settings/[tab]`}>
       <StyledLink href="" active={activeTab === tab}>
         <Icon icon={icon} />
         {label}


### PR DESCRIPTION
## Why

```
GET https://tadoku.app/_next/static/dpt70P7QKuNLGZen5hJcV/pages/contest-profile/1/1.js net::ERR_ABORTED 404
```
There were a bunch of errors like this because I was handling links the wrong way

## What

Fix link components `href` attribute.