### PR TITLE
Add About & Manual page

### DIFF
--- a/src/app/blog/api.ts
+++ b/src/app/blog/api.ts
@@ -25,9 +25,24 @@ const getPosts = async (): Promise<PostOrPage[]> => {
     .map(RawToPostOrPageMapper)
 }
 
+const getPage = async (slug: string): Promise<PostOrPage> => {
+  const response = await api.pages.read(
+    // @ts-ignore, upstream type isn't defined correctly
+    { slug },
+    {
+      formats: ['html'],
+    },
+  )
+
+  return RawToPostOrPageMapper(response)
+}
+
 const BlogApi = {
   posts: {
     list: getPosts,
+  },
+  pages: {
+    get: getPage,
   },
 }
 

--- a/src/app/blog/api.ts
+++ b/src/app/blog/api.ts
@@ -28,7 +28,9 @@ const getPosts = async (): Promise<Post[]> => {
 }
 
 const BlogApi = {
-  get: getPosts,
+  posts: {
+    list: getPosts,
+  },
 }
 
 export default BlogApi

--- a/src/app/blog/api.ts
+++ b/src/app/blog/api.ts
@@ -1,5 +1,6 @@
 import GhostContentAPI from '@tryghost/content-api'
-import { Post } from './domain'
+import { PostOrPage } from './interfaces'
+import { RawToPostOrPageMapper } from './transform'
 
 const api = GhostContentAPI({
   url: process.env.GHOST_URL || '',
@@ -7,7 +8,7 @@ const api = GhostContentAPI({
   version: 'canary',
 })
 
-const getPosts = async (): Promise<Post[]> => {
+const getPosts = async (): Promise<PostOrPage[]> => {
   const response = await api.posts.browse({
     limit: 5,
     include: ['authors', 'tags'],
@@ -20,11 +21,8 @@ const getPosts = async (): Promise<Post[]> => {
 
   return Object.entries(response)
     .filter(([key]) => key !== 'meta')
-    .map(([, p]) => ({
-      uuid: p.uuid,
-      title: p.title,
-      html: p.html,
-    }))
+    .map(([, p]) => p)
+    .map(RawToPostOrPageMapper)
 }
 
 const BlogApi = {

--- a/src/app/blog/components/BlogPost.tsx
+++ b/src/app/blog/components/BlogPost.tsx
@@ -1,17 +1,20 @@
 import React from 'react'
 import styled from 'styled-components'
 import { PostOrPage } from '../interfaces'
+import { PageTitle } from '../../ui/components'
 
 const BlogPost = ({ post }: { post: PostOrPage }) => (
   <Container>
-    <Title>{post.title}</Title>
+    <PageTitle>{post.title}</PageTitle>
     <Content dangerouslySetInnerHTML={{ __html: post.html }} />
   </Container>
 )
 
 export default BlogPost
 
-const Container = styled.div``
+const Container = styled.div`
+  max-width: 700px;
+  margin: 0 auto;
+`
 
-const Title = styled.h2``
 const Content = styled.div``

--- a/src/app/blog/components/BlogPost.tsx
+++ b/src/app/blog/components/BlogPost.tsx
@@ -1,8 +1,8 @@
 import React from 'react'
 import styled from 'styled-components'
-import { Post } from '../domain'
+import { PostOrPage } from '../interfaces'
 
-const BlogPost = ({ post }: { post: Post }) => (
+const BlogPost = ({ post }: { post: PostOrPage }) => (
   <Container>
     <Title>{post.title}</Title>
     <Content dangerouslySetInnerHTML={{ __html: post.html }} />

--- a/src/app/blog/components/BlogPost.tsx
+++ b/src/app/blog/components/BlogPost.tsx
@@ -12,9 +12,6 @@ const BlogPost = ({ post }: { post: PostOrPage }) => (
 
 export default BlogPost
 
-const Container = styled.div`
-  max-width: 700px;
-  margin: 0 auto;
-`
+const Container = styled.div``
 
 const Content = styled.div``

--- a/src/app/blog/domain.ts
+++ b/src/app/blog/domain.ts
@@ -1,5 +1,0 @@
-export interface Post {
-  uuid: string
-  title: string
-  html: string
-}

--- a/src/app/blog/interfaces.ts
+++ b/src/app/blog/interfaces.ts
@@ -1,0 +1,11 @@
+export interface RawPostOrPage {
+  slug: string
+  title?: string
+  html?: string
+}
+
+export interface PostOrPage {
+  slug: string
+  title: string
+  html: string
+}

--- a/src/app/blog/pages/BlogsList.tsx
+++ b/src/app/blog/pages/BlogsList.tsx
@@ -9,7 +9,7 @@ const BlogsList = () => {
   const { data: posts } = useCachedApiState<Post[]>({
     cacheKey: `blog_list?i=1`,
     defaultValue: [],
-    fetchData: BlogApi.get,
+    fetchData: BlogApi.posts.list,
     dependencies: [],
   })
 

--- a/src/app/blog/pages/BlogsList.tsx
+++ b/src/app/blog/pages/BlogsList.tsx
@@ -2,11 +2,11 @@ import React from 'react'
 import BlogApi from '../api'
 import { PageTitle } from '../../ui/components'
 import { useCachedApiState } from '../../cache'
-import { Post } from '../domain'
+import { PostOrPage } from '../interfaces'
 import BlogPost from '../components/BlogPost'
 
 const BlogsList = () => {
-  const { data: posts } = useCachedApiState<Post[]>({
+  const { data: posts } = useCachedApiState<PostOrPage[]>({
     cacheKey: `blog_list?i=1`,
     defaultValue: [],
     fetchData: BlogApi.posts.list,
@@ -17,7 +17,7 @@ const BlogsList = () => {
     <>
       <PageTitle>Blog</PageTitle>
       {posts.map(p => (
-        <BlogPost key={p.uuid} post={p} />
+        <BlogPost key={p.slug} post={p} />
       ))}
     </>
   )

--- a/src/app/blog/pages/PostOrPageDetail.tsx
+++ b/src/app/blog/pages/PostOrPageDetail.tsx
@@ -10,7 +10,7 @@ interface Props {
 
 const PostOrPageDetail = ({ slug }: Props) => {
   const { data: page } = useCachedApiState<PostOrPage | undefined>({
-    cacheKey: `blog_page?i=1`,
+    cacheKey: `blog_page?i=1&slug=${slug}`,
     defaultValue: undefined,
     fetchData: () => BlogApi.pages.get(slug),
     dependencies: [],

--- a/src/app/blog/pages/PostOrPageDetail.tsx
+++ b/src/app/blog/pages/PostOrPageDetail.tsx
@@ -1,0 +1,26 @@
+import React from 'react'
+import BlogApi from '../api'
+import { useCachedApiState } from '../../cache'
+import BlogPost from '../components/BlogPost'
+import { PostOrPage } from '../interfaces'
+
+interface Props {
+  slug: string
+}
+
+const PostOrPageDetail = ({ slug }: Props) => {
+  const { data: page } = useCachedApiState<PostOrPage | undefined>({
+    cacheKey: `blog_page?i=1`,
+    defaultValue: undefined,
+    fetchData: () => BlogApi.pages.get(slug),
+    dependencies: [],
+  })
+
+  if (!page) {
+    return null
+  }
+
+  return <BlogPost post={page} />
+}
+
+export default PostOrPageDetail

--- a/src/app/blog/transform.ts
+++ b/src/app/blog/transform.ts
@@ -1,0 +1,11 @@
+import { RawPostOrPage, PostOrPage } from './interfaces'
+import { Mapper } from '../interfaces'
+
+export const RawToPostOrPageMapper: Mapper<
+  RawPostOrPage,
+  PostOrPage
+> = raw => ({
+  slug: raw.slug,
+  title: raw.title ?? '',
+  html: raw.html ?? '',
+})

--- a/src/app/ui/components/navigation/ActiveUserNavigationBar.tsx
+++ b/src/app/ui/components/navigation/ActiveUserNavigationBar.tsx
@@ -37,6 +37,11 @@ export const ActiveUserNavigationBar = ({
           <Button plain>Manual</Button>
         </a>
       </Link>
+      <Link href="/about">
+        <a href="">
+          <Button plain>About</Button>
+        </a>
+      </Link>
       <SubmitPagesLink
         registration={registration}
         refreshRanking={refreshRanking}

--- a/src/app/ui/components/navigation/ActiveUserNavigationBar.tsx
+++ b/src/app/ui/components/navigation/ActiveUserNavigationBar.tsx
@@ -32,6 +32,11 @@ export const ActiveUserNavigationBar = ({
           <Button plain>Ranking</Button>
         </a>
       </Link>
+      <Link href="/manual">
+        <a href="">
+          <Button plain>Manual</Button>
+        </a>
+      </Link>
       <SubmitPagesLink
         registration={registration}
         refreshRanking={refreshRanking}

--- a/src/app/ui/components/navigation/AnonymousNavigationBar.tsx
+++ b/src/app/ui/components/navigation/AnonymousNavigationBar.tsx
@@ -15,14 +15,19 @@ export const AnonymousNavigationBar = ({
         <Button plain>Blog</Button>
       </a>
     </Link>
+    <Link href="/ranking">
+      <a href="">
+        <Button plain>Ranking</Button>
+      </a>
+    </Link>
     <Link href="/manual">
       <a href="">
         <Button plain>Manual</Button>
       </a>
     </Link>
-    <Link href="/ranking">
+    <Link href="/about">
       <a href="">
-        <Button plain>Ranking</Button>
+        <Button plain>About</Button>
       </a>
     </Link>
     <LogInLink refreshSession={refreshSession} />

--- a/src/app/ui/components/navigation/AnonymousNavigationBar.tsx
+++ b/src/app/ui/components/navigation/AnonymousNavigationBar.tsx
@@ -15,6 +15,11 @@ export const AnonymousNavigationBar = ({
         <Button plain>Blog</Button>
       </a>
     </Link>
+    <Link href="/manual">
+      <a href="">
+        <Button plain>Manual</Button>
+      </a>
+    </Link>
     <Link href="/ranking">
       <a href="">
         <Button plain>Ranking</Button>

--- a/src/pages/about.tsx
+++ b/src/pages/about.tsx
@@ -3,13 +3,13 @@ import Head from 'next/head'
 import styled from 'styled-components'
 import PostOrPageDetail from '../app/blog/pages/PostOrPageDetail'
 
-const Manual = () => (
+const About = () => (
   <>
     <Head>
-      <title>Tadoku - Manual</title>
+      <title>Tadoku - About</title>
     </Head>
     <Container>
-      <PostOrPageDetail slug="manual" />
+      <PostOrPageDetail slug="about" />
     </Container>
   </>
 )
@@ -19,4 +19,4 @@ const Container = styled.div`
   max-width: 700px;
 `
 
-export default Manual
+export default About

--- a/src/pages/manual.tsx
+++ b/src/pages/manual.tsx
@@ -1,0 +1,14 @@
+import React from 'react'
+import Head from 'next/head'
+import PostOrPageDetail from '../app/blog/pages/PostOrPageDetail'
+
+const Blog = () => (
+  <>
+    <Head>
+      <title>Tadoku - Manual</title>
+    </Head>
+    <PostOrPageDetail slug="manual" />
+  </>
+)
+
+export default Blog

--- a/src/pages/manual.tsx
+++ b/src/pages/manual.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import Head from 'next/head'
+import styled from 'styled-components'
 import PostOrPageDetail from '../app/blog/pages/PostOrPageDetail'
 
 const Blog = () => (
@@ -7,8 +8,15 @@ const Blog = () => (
     <Head>
       <title>Tadoku - Manual</title>
     </Head>
-    <PostOrPageDetail slug="manual" />
+    <Container>
+      <PostOrPageDetail slug="manual" />
+    </Container>
   </>
 )
+
+const Container = styled.div`
+  margin: 0 auto;
+  max-width: 700px;
+`
 
 export default Blog


### PR DESCRIPTION
## Why

We need to show the about and manual page that is managed by Ghost.

## What

* [x] Implement api endpoints to fetch the page data
* [x] Refactor some of the Ghost api stuff
* [x] Add page component