### PR TITLE
Add link to user's current contest profile to dropdown

### DIFF
--- a/src/app/session/components/navigation/UserMenu.tsx
+++ b/src/app/session/components/navigation/UserMenu.tsx
@@ -1,35 +1,74 @@
 import React from 'react'
-import { User } from '../../interfaces'
 import LogOutLink from './LogOut'
 import Dropdown, { DropdownItem } from '../../../ui/components/Dropdown'
 import { Button } from '../../../ui/components'
 import Link from 'next/link'
 import { SettingsTab } from '../../../user/interfaces'
 
+import { RankingRegistration } from '../../../ranking/interfaces'
+import { User } from '../../interfaces'
+
 interface Props {
   user: User
+  registration: RankingRegistration | undefined
 }
 
-const UserProfile = ({ user }: Props) => (
-  <Dropdown label={user.displayName}>
+const Settings = () => (
+  <DropdownItem>
+    <Link
+      href="/settings/[tab]"
+      as={`/settings/${SettingsTab.Profile}`}
+      passHref
+    >
+      {/* TODO: Remove span once https://github.com/zeit/next.js/issues/7915 is fixed */}
+      <span>
+        <Button plain icon="cog">
+          Settings
+        </Button>
+      </span>
+    </Link>
+  </DropdownItem>
+)
+
+interface ProfileLinkProps {
+  user: User
+  registration: RankingRegistration
+}
+const ContestProfile = ({ user, registration }: ProfileLinkProps) => {
+  return (
     <DropdownItem>
       <Link
-        href="/settings/[tab]"
-        as={`/settings/${SettingsTab.Profile}`}
-        passHref
+        href="/contest-profile/[tab]/[tab]"
+        as={`/contest-profile/${registration.contestId}/${user.id}`}
       >
         {/* TODO: Remove span once https://github.com/zeit/next.js/issues/7915 is fixed */}
         <span>
-          <Button plain icon="cog">
-            Settings
+          <Button plain icon="user">
+            Profile
           </Button>
         </span>
       </Link>
     </DropdownItem>
-    <DropdownItem>
-      <LogOutLink />
-    </DropdownItem>
-  </Dropdown>
-)
+  )
+}
 
-export default UserProfile
+const UserMenu = ({ user, registration }: Props) => {
+  return registration ? (
+    <Dropdown label={user.displayName}>
+      <Settings />
+      <ContestProfile user={user} registration={registration}></ContestProfile>
+      <DropdownItem>
+        <LogOutLink />
+      </DropdownItem>
+    </Dropdown>
+  ) : (
+    <Dropdown label={user.displayName}>
+      <Settings />
+      <DropdownItem>
+        <LogOutLink />
+      </DropdownItem>
+    </Dropdown>
+  )
+}
+
+export default UserMenu

--- a/src/app/ui/components/navigation/ActiveUserNavigationBar.tsx
+++ b/src/app/ui/components/navigation/ActiveUserNavigationBar.tsx
@@ -6,7 +6,7 @@ import Link from 'next/link'
 import { RankingRegistration } from '../../../ranking/interfaces'
 import SubmitPagesLink from '../../../ranking/components/navigation/SubmitPages'
 import { User } from '../../../session/interfaces'
-import UserProfile from '../../../session/components/navigation/UserMenu'
+import UserMenu from '../../../session/components/navigation/UserMenu'
 import { Button } from '..'
 
 interface Props {
@@ -47,9 +47,9 @@ export const ActiveUserNavigationBar = ({
         refreshRanking={refreshRanking}
       />
     </LinkContainer>
-    <UserProfileContainer>
-      <UserProfile user={user} />
-    </UserProfileContainer>
+    <UserMenuContainer>
+      <UserMenu user={user} registration={registration} />
+    </UserMenuContainer>
   </>
 )
 
@@ -69,7 +69,7 @@ const LinkContainer = styled.div`
   }
 `
 
-const UserProfileContainer = styled.div`
+const UserMenuContainer = styled.div`
   display: flex;
   align-items: center;
 


### PR DESCRIPTION
Renamed the exported `UserProfile` element to `UserMenu` to reflect the filename and what it actually is. 

Manually tested by spinning up a local app:

<img width="738" alt="Screenshot 2020-02-11 at 12 26 28" src="https://user-images.githubusercontent.com/8013000/74209222-3553a380-4cca-11ea-9bf0-aa5dbd3b4583.png">
