### PR TITLE
Refactor mappers

### DIFF
--- a/src/app/blog/api.ts
+++ b/src/app/blog/api.ts
@@ -1,6 +1,6 @@
 import GhostContentAPI from '@tryghost/content-api'
 import { PostOrPage } from './interfaces'
-import { rawToPostOrPageMapper } from './transform'
+import { postOrPageMapper } from './transform'
 
 const api = GhostContentAPI({
   url: process.env.GHOST_URL || '',
@@ -22,7 +22,7 @@ const getPosts = async (): Promise<PostOrPage[]> => {
   return Object.entries(response)
     .filter(([key]) => key !== 'meta')
     .map(([, p]) => p)
-    .map(rawToPostOrPageMapper)
+    .map(postOrPageMapper.fromRaw)
 }
 
 const getPage = async (slug: string): Promise<PostOrPage> => {
@@ -33,7 +33,7 @@ const getPage = async (slug: string): Promise<PostOrPage> => {
     },
   )
 
-  return rawToPostOrPageMapper(response)
+  return postOrPageMapper.fromRaw(response)
 }
 
 const BlogApi = {

--- a/src/app/blog/api.ts
+++ b/src/app/blog/api.ts
@@ -1,6 +1,6 @@
 import GhostContentAPI from '@tryghost/content-api'
 import { PostOrPage } from './interfaces'
-import { RawToPostOrPageMapper } from './transform'
+import { rawToPostOrPageMapper } from './transform'
 
 const api = GhostContentAPI({
   url: process.env.GHOST_URL || '',
@@ -22,7 +22,7 @@ const getPosts = async (): Promise<PostOrPage[]> => {
   return Object.entries(response)
     .filter(([key]) => key !== 'meta')
     .map(([, p]) => p)
-    .map(RawToPostOrPageMapper)
+    .map(rawToPostOrPageMapper)
 }
 
 const getPage = async (slug: string): Promise<PostOrPage> => {
@@ -33,7 +33,7 @@ const getPage = async (slug: string): Promise<PostOrPage> => {
     },
   )
 
-  return RawToPostOrPageMapper(response)
+  return rawToPostOrPageMapper(response)
 }
 
 const BlogApi = {

--- a/src/app/blog/pages/BlogsList.tsx
+++ b/src/app/blog/pages/BlogsList.tsx
@@ -4,7 +4,7 @@ import { PageTitle } from '../../ui/components'
 import { useCachedApiState } from '../../cache'
 import { PostOrPage } from '../interfaces'
 import BlogPost from '../components/BlogPost'
-import { postOrPagesSerializer } from '../transform'
+import { postOrPageCollectionSerializer } from '../transform'
 
 const BlogsList = () => {
   const { data: posts } = useCachedApiState<PostOrPage[]>({
@@ -12,7 +12,7 @@ const BlogsList = () => {
     defaultValue: [],
     fetchData: BlogApi.posts.list,
     dependencies: [],
-    serializer: postOrPagesSerializer,
+    serializer: postOrPageCollectionSerializer,
   })
 
   return (

--- a/src/app/blog/pages/BlogsList.tsx
+++ b/src/app/blog/pages/BlogsList.tsx
@@ -4,7 +4,7 @@ import { PageTitle } from '../../ui/components'
 import { useCachedApiState } from '../../cache'
 import { PostOrPage } from '../interfaces'
 import BlogPost from '../components/BlogPost'
-import { PostOrPagesSerializer } from '../transform'
+import { postOrPagesSerializer } from '../transform'
 
 const BlogsList = () => {
   const { data: posts } = useCachedApiState<PostOrPage[]>({
@@ -12,7 +12,7 @@ const BlogsList = () => {
     defaultValue: [],
     fetchData: BlogApi.posts.list,
     dependencies: [],
-    serializer: PostOrPagesSerializer,
+    serializer: postOrPagesSerializer,
   })
 
   return (

--- a/src/app/blog/pages/PostOrPageDetail.tsx
+++ b/src/app/blog/pages/PostOrPageDetail.tsx
@@ -3,8 +3,8 @@ import BlogApi from '../api'
 import { useCachedApiState } from '../../cache'
 import BlogPage from '../components/BlogPage'
 import { PostOrPage } from '../interfaces'
-import { PostOrPageSerializer } from '../transform'
-import { OptionalizeSerializer } from '../../transform'
+import { postOrPageSerializer } from '../transform'
+import { optionalizeSerializer } from '../../transform'
 
 interface Props {
   slug: string
@@ -16,7 +16,7 @@ const PostOrPageDetail = ({ slug }: Props) => {
     defaultValue: undefined,
     fetchData: () => BlogApi.pages.get(slug),
     dependencies: [],
-    serializer: OptionalizeSerializer(PostOrPageSerializer),
+    serializer: optionalizeSerializer(postOrPageSerializer),
   })
 
   if (!page) {

--- a/src/app/blog/transform.ts
+++ b/src/app/blog/transform.ts
@@ -2,7 +2,7 @@ import { PostOrPage } from './interfaces'
 import { PostOrPage as RawPostOrPage } from '@tryghost/content-api'
 import { Mapper, Mappers } from '../interfaces'
 import { Serializer } from '../cache'
-import { createSerializer } from '../transform'
+import { createSerializer, createMappers } from '../transform'
 
 const rawToPostOrPageMapper: Mapper<RawPostOrPage, PostOrPage> = raw => ({
   id: raw.id,
@@ -23,10 +23,13 @@ const postOrPageToRawMapper: Mapper<
   published_at: postOrPage.publishedAt.toISOString(),
 })
 
-export const postOrPageMapper: Mappers<RawPostOrPage, PostOrPage> = {
+export const postOrPageMapper: Mappers<
+  RawPostOrPage,
+  PostOrPage
+> = createMappers({
   fromRaw: rawToPostOrPageMapper,
   toRaw: postOrPageToRawMapper,
-}
+})
 
 export const postOrPageSerializer = createSerializer(postOrPageMapper)
 

--- a/src/app/blog/transform.ts
+++ b/src/app/blog/transform.ts
@@ -35,7 +35,9 @@ export const postOrPageMapper: Mappers<
   toRaw: postOrPageToRawMapper,
 })
 
-export const postOrPageSerializer = createSerializer(postOrPageMapper)
+export const postOrPageSerializer: Serializer<PostOrPage> = createSerializer(
+  postOrPageMapper,
+)
 
 export const postOrPagesSerializer: Serializer<
   PostOrPage[]

--- a/src/app/blog/transform.ts
+++ b/src/app/blog/transform.ts
@@ -1,12 +1,10 @@
 import { PostOrPage } from './interfaces'
 import { PostOrPage as RawPostOrPage } from '@tryghost/content-api'
-import { Mapper } from '../interfaces'
+import { Mapper, Mappers } from '../interfaces'
 import { Serializer } from '../cache'
+import { createSerializer } from '../transform'
 
-export const rawToPostOrPageMapper: Mapper<
-  RawPostOrPage,
-  PostOrPage
-> = raw => ({
+const rawToPostOrPageMapper: Mapper<RawPostOrPage, PostOrPage> = raw => ({
   id: raw.id,
   slug: raw.slug,
   title: raw.title ?? '',
@@ -25,16 +23,12 @@ const postOrPageToRawMapper: Mapper<
   published_at: postOrPage.publishedAt.toISOString(),
 })
 
-export const postOrPageSerializer: Serializer<PostOrPage> = {
-  serialize: postOrPage => {
-    let raw = postOrPageToRawMapper(postOrPage)
-    return JSON.stringify(raw)
-  },
-  deserialize: serializedData => {
-    let raw = JSON.parse(serializedData)
-    return rawToPostOrPageMapper(raw)
-  },
+export const postOrPageMapper: Mappers<RawPostOrPage, PostOrPage> = {
+  fromRaw: rawToPostOrPageMapper,
+  toRaw: postOrPageToRawMapper,
 }
+
+export const postOrPageSerializer = createSerializer(postOrPageMapper)
 
 export const postOrPagesSerializer: Serializer<PostOrPage[]> = {
   serialize: postOrPages => {

--- a/src/app/blog/transform.ts
+++ b/src/app/blog/transform.ts
@@ -3,7 +3,7 @@ import { PostOrPage as RawPostOrPage } from '@tryghost/content-api'
 import { Mapper } from '../interfaces'
 import { Serializer } from '../cache'
 
-export const RawToPostOrPageMapper: Mapper<
+export const rawToPostOrPageMapper: Mapper<
   RawPostOrPage,
   PostOrPage
 > = raw => ({
@@ -14,7 +14,7 @@ export const RawToPostOrPageMapper: Mapper<
   publishedAt: raw.published_at ? new Date(raw.published_at) : new Date(),
 })
 
-const PostOrPageToRawMapper: Mapper<
+const postOrPageToRawMapper: Mapper<
   PostOrPage,
   RawPostOrPage
 > = postOrPage => ({
@@ -25,24 +25,24 @@ const PostOrPageToRawMapper: Mapper<
   published_at: postOrPage.publishedAt.toISOString(),
 })
 
-export const PostOrPageSerializer: Serializer<PostOrPage> = {
+export const postOrPageSerializer: Serializer<PostOrPage> = {
   serialize: postOrPage => {
-    let raw = PostOrPageToRawMapper(postOrPage)
+    let raw = postOrPageToRawMapper(postOrPage)
     return JSON.stringify(raw)
   },
   deserialize: serializedData => {
     let raw = JSON.parse(serializedData)
-    return RawToPostOrPageMapper(raw)
+    return rawToPostOrPageMapper(raw)
   },
 }
 
-export const PostOrPagesSerializer: Serializer<PostOrPage[]> = {
+export const postOrPagesSerializer: Serializer<PostOrPage[]> = {
   serialize: postOrPages => {
-    const raw = postOrPages.map(PostOrPageToRawMapper)
+    const raw = postOrPages.map(postOrPageToRawMapper)
     return JSON.stringify(raw)
   },
   deserialize: serializedData => {
     let raw = JSON.parse(serializedData)
-    return raw.map(RawToPostOrPageMapper)
+    return raw.map(rawToPostOrPageMapper)
   },
 }

--- a/src/app/blog/transform.ts
+++ b/src/app/blog/transform.ts
@@ -2,7 +2,11 @@ import { PostOrPage } from './interfaces'
 import { PostOrPage as RawPostOrPage } from '@tryghost/content-api'
 import { Mapper, Mappers } from '../interfaces'
 import { Serializer } from '../cache'
-import { createSerializer, createMappers } from '../transform'
+import {
+  createSerializer,
+  createMappers,
+  createCollectionSerializer,
+} from '../transform'
 
 const rawToPostOrPageMapper: Mapper<RawPostOrPage, PostOrPage> = raw => ({
   id: raw.id,
@@ -33,13 +37,6 @@ export const postOrPageMapper: Mappers<
 
 export const postOrPageSerializer = createSerializer(postOrPageMapper)
 
-export const postOrPagesSerializer: Serializer<PostOrPage[]> = {
-  serialize: postOrPages => {
-    const raw = postOrPages.map(postOrPageToRawMapper)
-    return JSON.stringify(raw)
-  },
-  deserialize: serializedData => {
-    let raw = JSON.parse(serializedData)
-    return raw.map(rawToPostOrPageMapper)
-  },
-}
+export const postOrPagesSerializer: Serializer<
+  PostOrPage[]
+> = createCollectionSerializer(postOrPageMapper)

--- a/src/app/blog/transform.ts
+++ b/src/app/blog/transform.ts
@@ -39,6 +39,6 @@ export const postOrPageSerializer: Serializer<PostOrPage> = createSerializer(
   postOrPageMapper,
 )
 
-export const postOrPagesSerializer: Serializer<
+export const postOrPageCollectionSerializer: Serializer<
   PostOrPage[]
 > = createCollectionSerializer(postOrPageMapper)

--- a/src/app/contest/api.ts
+++ b/src/app/contest/api.ts
@@ -1,6 +1,6 @@
 import { get } from '../api'
 import { Contest, RawContest } from './interfaces'
-import { ContestMapper } from './transform'
+import { contestMapper } from './transform'
 
 const getContest = async (contestId: number): Promise<Contest | undefined> => {
   const response = await get(`/contests/${contestId}`)
@@ -11,7 +11,7 @@ const getContest = async (contestId: number): Promise<Contest | undefined> => {
 
   const data: RawContest = await response.json()
 
-  return ContestMapper.fromRaw(data)
+  return contestMapper.fromRaw(data)
 }
 
 const getAll = async (limit?: number): Promise<Contest[]> => {
@@ -24,7 +24,7 @@ const getAll = async (limit?: number): Promise<Contest[]> => {
 
   const data: RawContest[] = await response.json()
 
-  return data.map(ContestMapper.fromRaw)
+  return data.map(contestMapper.fromRaw)
 }
 
 const ContestApi = {

--- a/src/app/contest/components/Effects.tsx
+++ b/src/app/contest/components/Effects.tsx
@@ -3,13 +3,13 @@ import { Contest } from '../interfaces'
 import ContestApi from '../api'
 import { updateRecentContests } from '../redux'
 import { useCachedApiState } from '../../cache'
-import { ContestMapper, ContestsSerializer } from '../transform'
+import { contestMapper, contestsSerializer } from '../transform'
 
 const ContestEffects = () => {
   const dispatch = useDispatch()
 
   const update = (contests: Contest[]) => {
-    const rawContests = contests.map(ContestMapper.toRaw)
+    const rawContests = contests.map(contestMapper.toRaw)
     dispatch(updateRecentContests(rawContests))
   }
 
@@ -18,7 +18,7 @@ const ContestEffects = () => {
     defaultValue: [] as Contest[],
     fetchData: async () => await ContestApi.getAll(5),
     onChange: update,
-    serializer: ContestsSerializer,
+    serializer: contestsSerializer,
   })
 
   return null

--- a/src/app/contest/components/Effects.tsx
+++ b/src/app/contest/components/Effects.tsx
@@ -3,7 +3,7 @@ import { Contest } from '../interfaces'
 import ContestApi from '../api'
 import { updateRecentContests } from '../redux'
 import { useCachedApiState } from '../../cache'
-import { contestMapper, contestsSerializer } from '../transform'
+import { contestMapper, contestCollectionSerializer } from '../transform'
 
 const ContestEffects = () => {
   const dispatch = useDispatch()
@@ -18,7 +18,7 @@ const ContestEffects = () => {
     defaultValue: [] as Contest[],
     fetchData: async () => await ContestApi.getAll(5),
     onChange: update,
-    serializer: contestsSerializer,
+    serializer: contestCollectionSerializer,
   })
 
   return null

--- a/src/app/contest/transform.ts
+++ b/src/app/contest/transform.ts
@@ -28,7 +28,9 @@ export const contestMapper: Mappers<RawContest, Contest> = createMappers({
   toRaw: contestToRawMapper,
 })
 
-export const contestSerializer = createSerializer(contestMapper)
+export const contestSerializer: Serializer<Contest> = createSerializer(
+  contestMapper,
+)
 
 export const contestsSerializer: Serializer<
   Contest[]

--- a/src/app/contest/transform.ts
+++ b/src/app/contest/transform.ts
@@ -1,7 +1,7 @@
 import { Contest, RawContest } from './interfaces'
 import { Mapper, Mappers } from '../interfaces'
 import { Serializer } from '../cache'
-import { createSerializer } from '../transform'
+import { createSerializer, createMappers } from '../transform'
 
 const rawToContestMapper: Mapper<RawContest, Contest> = raw => ({
   id: raw.id,
@@ -19,10 +19,10 @@ const contestToRawMapper: Mapper<Contest, RawContest> = contest => ({
   open: contest.open,
 })
 
-export const contestMapper: Mappers<RawContest, Contest> = {
+export const contestMapper: Mappers<RawContest, Contest> = createMappers({
   fromRaw: rawToContestMapper,
   toRaw: contestToRawMapper,
-}
+})
 
 export const contestSerializer = createSerializer(contestMapper)
 

--- a/src/app/contest/transform.ts
+++ b/src/app/contest/transform.ts
@@ -32,6 +32,6 @@ export const contestSerializer: Serializer<Contest> = createSerializer(
   contestMapper,
 )
 
-export const contestsSerializer: Serializer<
+export const contestCollectionSerializer: Serializer<
   Contest[]
 > = createCollectionSerializer(contestMapper)

--- a/src/app/contest/transform.ts
+++ b/src/app/contest/transform.ts
@@ -3,7 +3,7 @@ import { Mapper } from '../interfaces'
 import { Serializer } from '../cache'
 import { withOptional } from '../transform'
 
-const RawToContestMapper: Mapper<RawContest, Contest> = raw => ({
+const rawToContestMapper: Mapper<RawContest, Contest> = raw => ({
   id: raw.id,
   description: raw.description,
   start: new Date(raw.start),
@@ -11,7 +11,7 @@ const RawToContestMapper: Mapper<RawContest, Contest> = raw => ({
   open: raw.open,
 })
 
-const ContestToRawMapper: Mapper<Contest, RawContest> = contest => ({
+const contestToRawMapper: Mapper<Contest, RawContest> = contest => ({
   id: contest.id,
   description: contest.description,
   start: contest.start.toISOString(),
@@ -19,29 +19,29 @@ const ContestToRawMapper: Mapper<Contest, RawContest> = contest => ({
   open: contest.open,
 })
 
-export const ContestSerializer: Serializer<Contest> = {
+export const contestSerializer: Serializer<Contest> = {
   serialize: contest => {
-    const raw = ContestToRawMapper(contest)
+    const raw = contestToRawMapper(contest)
     return JSON.stringify(raw)
   },
   deserialize: serializedData => {
     let raw = JSON.parse(serializedData)
-    return RawToContestMapper(raw)
+    return rawToContestMapper(raw)
   },
 }
 
-export const ContestsSerializer: Serializer<Contest[]> = {
+export const contestsSerializer: Serializer<Contest[]> = {
   serialize: contests => {
-    const raw = contests.map(ContestToRawMapper)
+    const raw = contests.map(contestToRawMapper)
     return JSON.stringify(raw)
   },
   deserialize: serializedData => {
     let raw = JSON.parse(serializedData)
-    return raw.map(RawToContestMapper)
+    return raw.map(rawToContestMapper)
   },
 }
 
-export const ContestMapper = withOptional({
-  toRaw: ContestToRawMapper,
-  fromRaw: RawToContestMapper,
+export const contestMapper = withOptional({
+  toRaw: contestToRawMapper,
+  fromRaw: rawToContestMapper,
 })

--- a/src/app/contest/transform.ts
+++ b/src/app/contest/transform.ts
@@ -1,7 +1,7 @@
 import { Contest, RawContest } from './interfaces'
-import { Mapper } from '../interfaces'
+import { Mapper, Mappers } from '../interfaces'
 import { Serializer } from '../cache'
-import { withOptional } from '../transform'
+import { createSerializer } from '../transform'
 
 const rawToContestMapper: Mapper<RawContest, Contest> = raw => ({
   id: raw.id,
@@ -19,16 +19,12 @@ const contestToRawMapper: Mapper<Contest, RawContest> = contest => ({
   open: contest.open,
 })
 
-export const contestSerializer: Serializer<Contest> = {
-  serialize: contest => {
-    const raw = contestToRawMapper(contest)
-    return JSON.stringify(raw)
-  },
-  deserialize: serializedData => {
-    let raw = JSON.parse(serializedData)
-    return rawToContestMapper(raw)
-  },
+export const contestMapper: Mappers<RawContest, Contest> = {
+  fromRaw: rawToContestMapper,
+  toRaw: contestToRawMapper,
 }
+
+export const contestSerializer = createSerializer(contestMapper)
 
 export const contestsSerializer: Serializer<Contest[]> = {
   serialize: contests => {
@@ -40,8 +36,3 @@ export const contestsSerializer: Serializer<Contest[]> = {
     return raw.map(rawToContestMapper)
   },
 }
-
-export const contestMapper = withOptional({
-  toRaw: contestToRawMapper,
-  fromRaw: rawToContestMapper,
-})

--- a/src/app/contest/transform.ts
+++ b/src/app/contest/transform.ts
@@ -1,7 +1,11 @@
 import { Contest, RawContest } from './interfaces'
 import { Mapper, Mappers } from '../interfaces'
 import { Serializer } from '../cache'
-import { createSerializer, createMappers } from '../transform'
+import {
+  createSerializer,
+  createMappers,
+  createCollectionSerializer,
+} from '../transform'
 
 const rawToContestMapper: Mapper<RawContest, Contest> = raw => ({
   id: raw.id,
@@ -26,13 +30,6 @@ export const contestMapper: Mappers<RawContest, Contest> = createMappers({
 
 export const contestSerializer = createSerializer(contestMapper)
 
-export const contestsSerializer: Serializer<Contest[]> = {
-  serialize: contests => {
-    const raw = contests.map(contestToRawMapper)
-    return JSON.stringify(raw)
-  },
-  deserialize: serializedData => {
-    let raw = JSON.parse(serializedData)
-    return raw.map(rawToContestMapper)
-  },
-}
+export const contestsSerializer: Serializer<
+  Contest[]
+> = createCollectionSerializer(contestMapper)

--- a/src/app/interfaces.ts
+++ b/src/app/interfaces.ts
@@ -3,10 +3,6 @@ export type Mapper<A, B> = (rawData: A) => B
 export interface Mappers<Raw, Original> {
   toRaw: (original: Original) => Raw
   fromRaw: (raw: Raw) => Original
-}
-
-export interface MappersWithOptional<Raw, Original>
-  extends Mappers<Raw, Original> {
   optional: {
     toRaw: (original: Original | undefined) => Raw | undefined
     fromRaw: (raw: Raw | undefined) => Original | undefined

--- a/src/app/landing/pages/landing.tsx
+++ b/src/app/landing/pages/landing.tsx
@@ -9,7 +9,7 @@ import * as RankingStore from '../../ranking/redux'
 import { FooterLanding } from '../../ui/components/Footer'
 import Constants from '../../ui/Constants'
 import { RootState } from '../../store'
-import { ContestMapper } from '../../contest/transform'
+import { contestMapper } from '../../contest/transform'
 
 const LandingPage = () => {
   const dispatch = useDispatch()
@@ -19,7 +19,7 @@ const LandingPage = () => {
 
   const [isLoginModalOpen, setIsLoginModalOpen] = useState(false)
   const contests = useSelector((state: RootState) =>
-    state.contest.recentContests.map(ContestMapper.fromRaw),
+    state.contest.recentContests.map(contestMapper.fromRaw),
   )
 
   return (

--- a/src/app/ranking/api.ts
+++ b/src/app/ranking/api.ts
@@ -7,8 +7,8 @@ import {
   ContestLog,
   RawContestLog,
 } from './interfaces'
-import { RankingMapper } from './transform/ranking'
-import { ContestLogMapper } from './transform/contest-log'
+import { rankingMapper } from './transform/ranking'
+import { contestLogMapper } from './transform/contest-log'
 
 const joinContest = async (
   contestId: number,
@@ -34,7 +34,7 @@ const getRankings = async (contestId?: number): Promise<Ranking[]> => {
 
   const data: RawRanking[] = await response.json()
 
-  return data.map(RankingMapper.fromRaw)
+  return data.map(rankingMapper.fromRaw)
 }
 
 const getCurrentRegistration = async (): Promise<
@@ -72,7 +72,7 @@ const getRankingsRegistration = async (
 
   const data: RawRanking[] = await response.json()
 
-  return data.map(RankingMapper.fromRaw)
+  return data.map(rankingMapper.fromRaw)
 }
 
 const createLog = async (payload: {
@@ -142,7 +142,7 @@ const getLogsFor = async (
 
   const data: RawContestLog[] = await response.json()
 
-  return data.map(ContestLogMapper.fromRaw)
+  return data.map(contestLogMapper.fromRaw)
 }
 
 const RankingApi = {

--- a/src/app/ranking/components/Effects.tsx
+++ b/src/app/ranking/components/Effects.tsx
@@ -4,10 +4,10 @@ import { RankingRegistration } from '../interfaces'
 import { RootState } from '../../store'
 import RankingApi from '../api'
 import { useCachedApiState } from '../../cache'
-import { OptionalizeSerializer } from '../../transform'
+import { optionalizeSerializer } from '../../transform'
 import {
-  RankingRegistrationSerializer,
-  RankingRegistrationMapper,
+  rankingRegistrationSerializer,
+  rankingRegistrationMapper,
 } from '../transform/ranking-registration'
 
 const RankingEffects = () => {
@@ -18,7 +18,7 @@ const RankingEffects = () => {
 
   const dispatch = useDispatch()
   const update = (registration: RankingRegistration | undefined) => {
-    const payload = RankingRegistrationMapper.optional.toRaw(registration)
+    const payload = rankingRegistrationMapper.optional.toRaw(registration)
     dispatch(updateRegistration(payload))
   }
 
@@ -36,7 +36,7 @@ const RankingEffects = () => {
     },
     onChange: update,
     dependencies: [user, effectCount],
-    serializer: OptionalizeSerializer(RankingRegistrationSerializer),
+    serializer: optionalizeSerializer(rankingRegistrationSerializer),
   })
 
   return null

--- a/src/app/ranking/components/forms/JoinContestForm.tsx
+++ b/src/app/ranking/components/forms/JoinContestForm.tsx
@@ -13,7 +13,7 @@ import { Button, StackContainer } from '../../../ui/components'
 import RankingApi from '../../api'
 import { Contest } from '../../../contest/interfaces'
 import { validateLanguageCode } from '../../domain'
-import { RankingRegistrationMapper } from '../../transform/ranking-registration'
+import { rankingRegistrationMapper } from '../../transform/ranking-registration'
 
 interface Props {
   contest: Contest
@@ -126,7 +126,7 @@ const JoinContestForm = ({
 
 const mapStateToProps = (state: RootState, oldProps: Props) => ({
   ...oldProps,
-  registration: RankingRegistrationMapper.optional.fromRaw(
+  registration: rankingRegistrationMapper.optional.fromRaw(
     state.ranking.rawRegistration,
   ),
 })

--- a/src/app/ranking/components/forms/LogForm.tsx
+++ b/src/app/ranking/components/forms/LogForm.tsx
@@ -17,7 +17,7 @@ import {
 } from '../../../ui/components/Form'
 import { Button, StackContainer } from '../../../ui/components'
 import { validateLanguageCode, validateAmount } from '../../domain'
-import { RankingRegistrationMapper } from '../../transform/ranking-registration'
+import { rankingRegistrationMapper } from '../../transform/ranking-registration'
 
 interface Props {
   log?: ContestLog
@@ -200,7 +200,7 @@ const LogForm = ({
 
 const mapStateToProps = (state: RootState, oldProps: Props) => ({
   ...oldProps,
-  registration: RankingRegistrationMapper.optional.fromRaw(
+  registration: rankingRegistrationMapper.optional.fromRaw(
     state.ranking.rawRegistration,
   ),
 })

--- a/src/app/ranking/pages/RankingOverview.tsx
+++ b/src/app/ranking/pages/RankingOverview.tsx
@@ -8,7 +8,7 @@ import styled from 'styled-components'
 import { User } from '../../session/interfaces'
 import JoinContestModal from '../components/modals/JoinContestModal'
 import { useCachedApiState, ApiFetchStatus } from '../../cache'
-import { RankingsSerializer } from '../transform/ranking'
+import { rankingsSerializer } from '../transform/ranking'
 import { isContestActive } from '../domain'
 import SubmitPagesButton from '../components/SubmitPagesButton'
 import Constants from '../../ui/Constants'
@@ -41,7 +41,7 @@ const RankingOverview = ({
       return RankingApi.get(contest.id)
     },
     dependencies: [contest?.id, effectCount],
-    serializer: RankingsSerializer,
+    serializer: rankingsSerializer,
   })
 
   // @TODO: extract this business logic

--- a/src/app/ranking/pages/RankingOverview.tsx
+++ b/src/app/ranking/pages/RankingOverview.tsx
@@ -8,7 +8,7 @@ import styled from 'styled-components'
 import { User } from '../../session/interfaces'
 import JoinContestModal from '../components/modals/JoinContestModal'
 import { useCachedApiState, ApiFetchStatus } from '../../cache'
-import { rankingsSerializer } from '../transform/ranking'
+import { rankingCollectionSerializer } from '../transform/ranking'
 import { isContestActive } from '../domain'
 import SubmitPagesButton from '../components/SubmitPagesButton'
 import Constants from '../../ui/Constants'
@@ -41,7 +41,7 @@ const RankingOverview = ({
       return RankingApi.get(contest.id)
     },
     dependencies: [contest?.id, effectCount],
-    serializer: rankingsSerializer,
+    serializer: rankingCollectionSerializer,
   })
 
   // @TODO: extract this business logic

--- a/src/app/ranking/pages/RankingProfile.tsx
+++ b/src/app/ranking/pages/RankingProfile.tsx
@@ -25,8 +25,8 @@ import { PageTitle, ButtonLink } from '../../ui/components'
 import { useSelector } from 'react-redux'
 import { RootState } from '../../store'
 import styled from 'styled-components'
-import { contestLogsSerializer } from '../transform/contest-log'
-import { rankingsSerializer } from '../transform/ranking'
+import { contestLogCollectionSerializer } from '../transform/contest-log'
+import { rankingCollectionSerializer } from '../transform/ranking'
 
 interface Props {
   contestId: number
@@ -75,7 +75,7 @@ const RankingProfile = ({
       })
     },
     dependencies: [contestId, userId, effectCount],
-    serializer: contestLogsSerializer,
+    serializer: contestLogCollectionSerializer,
   })
 
   const { data: registration, status: statusRegistration } = useCachedApiState<
@@ -87,7 +87,7 @@ const RankingProfile = ({
       return RankingApi.getRankingsRegistration(contestId, userId)
     },
     dependencies: [contestId, userId, effectCount],
-    serializer: rankingsSerializer,
+    serializer: rankingCollectionSerializer,
   })
 
   if (!isReady([statusContest, statusLogs, statusRegistration])) {

--- a/src/app/ranking/pages/RankingProfile.tsx
+++ b/src/app/ranking/pages/RankingProfile.tsx
@@ -19,14 +19,14 @@ import Cards, {
   LargeCard,
 } from '../../ui/components/Cards'
 import { useCachedApiState, isReady } from '../../cache'
-import { ContestSerializer } from '../../contest/transform'
-import { OptionalizeSerializer } from '../../transform'
+import { contestSerializer } from '../../contest/transform'
+import { optionalizeSerializer } from '../../transform'
 import { PageTitle, ButtonLink } from '../../ui/components'
 import { useSelector } from 'react-redux'
 import { RootState } from '../../store'
 import styled from 'styled-components'
-import { ContestLogsSerializer } from '../transform/contest-log'
-import { RankingsSerializer } from '../transform/ranking'
+import { contestLogsSerializer } from '../transform/contest-log'
+import { rankingsSerializer } from '../transform/ranking'
 
 interface Props {
   contestId: number
@@ -51,7 +51,7 @@ const RankingProfile = ({
       return ContestApi.get(contestId)
     },
     dependencies: [contestId],
-    serializer: OptionalizeSerializer(ContestSerializer),
+    serializer: optionalizeSerializer(contestSerializer),
   })
 
   const { data: logs, status: statusLogs } = useCachedApiState<ContestLog[]>({
@@ -75,7 +75,7 @@ const RankingProfile = ({
       })
     },
     dependencies: [contestId, userId, effectCount],
-    serializer: ContestLogsSerializer,
+    serializer: contestLogsSerializer,
   })
 
   const { data: registration, status: statusRegistration } = useCachedApiState<
@@ -87,7 +87,7 @@ const RankingProfile = ({
       return RankingApi.getRankingsRegistration(contestId, userId)
     },
     dependencies: [contestId, userId, effectCount],
-    serializer: RankingsSerializer,
+    serializer: rankingsSerializer,
   })
 
   if (!isReady([statusContest, statusLogs, statusRegistration])) {

--- a/src/app/ranking/transform/contest-log.ts
+++ b/src/app/ranking/transform/contest-log.ts
@@ -38,6 +38,6 @@ export const contestLogMapper: Mappers<
   fromRaw: rawToContestLogMapper,
 })
 
-export const contestLogsSerializer: Serializer<
+export const contestLogCollectionSerializer: Serializer<
   ContestLog[]
 > = createCollectionSerializer(contestLogMapper)

--- a/src/app/ranking/transform/contest-log.ts
+++ b/src/app/ranking/transform/contest-log.ts
@@ -2,7 +2,7 @@ import { ContestLog, RawContestLog } from './../interfaces'
 import { Mapper } from '../../interfaces'
 import { Serializer } from '../../cache'
 
-const RawToContestLogMapper: Mapper<RawContestLog, ContestLog> = raw => ({
+const rawToContestLogMapper: Mapper<RawContestLog, ContestLog> = raw => ({
   id: raw.id,
   contestId: raw.contest_id,
   userId: raw.user_id,
@@ -14,7 +14,7 @@ const RawToContestLogMapper: Mapper<RawContestLog, ContestLog> = raw => ({
   date: new Date(raw.date),
 })
 
-const ContestLogToRawMapper: Mapper<
+const contestLogToRawMapper: Mapper<
   ContestLog,
   RawContestLog
 > = contestLog => ({
@@ -29,18 +29,18 @@ const ContestLogToRawMapper: Mapper<
   date: contestLog.date.toISOString(),
 })
 
-export const ContestLogsSerializer: Serializer<ContestLog[]> = {
+export const contestLogsSerializer: Serializer<ContestLog[]> = {
   serialize: data => {
-    const raw = data.map(ContestLogToRawMapper)
+    const raw = data.map(contestLogToRawMapper)
     return JSON.stringify(raw)
   },
   deserialize: serializedData => {
     let raw = JSON.parse(serializedData)
-    return raw.map(RawToContestLogMapper)
+    return raw.map(rawToContestLogMapper)
   },
 }
 
-export const ContestLogMapper = {
-  toRaw: ContestLogToRawMapper,
-  fromRaw: RawToContestLogMapper,
+export const contestLogMapper = {
+  toRaw: contestLogToRawMapper,
+  fromRaw: rawToContestLogMapper,
 }

--- a/src/app/ranking/transform/contest-log.ts
+++ b/src/app/ranking/transform/contest-log.ts
@@ -1,6 +1,7 @@
 import { ContestLog, RawContestLog } from './../interfaces'
-import { Mapper } from '../../interfaces'
+import { Mapper, Mappers } from '../../interfaces'
 import { Serializer } from '../../cache'
+import { createCollectionSerializer, createMappers } from '../../transform'
 
 const rawToContestLogMapper: Mapper<RawContestLog, ContestLog> = raw => ({
   id: raw.id,
@@ -29,18 +30,14 @@ const contestLogToRawMapper: Mapper<
   date: contestLog.date.toISOString(),
 })
 
-export const contestLogsSerializer: Serializer<ContestLog[]> = {
-  serialize: data => {
-    const raw = data.map(contestLogToRawMapper)
-    return JSON.stringify(raw)
-  },
-  deserialize: serializedData => {
-    let raw = JSON.parse(serializedData)
-    return raw.map(rawToContestLogMapper)
-  },
-}
-
-export const contestLogMapper = {
+export const contestLogMapper: Mappers<
+  RawContestLog,
+  ContestLog
+> = createMappers({
   toRaw: contestLogToRawMapper,
   fromRaw: rawToContestLogMapper,
-}
+})
+
+export const contestLogsSerializer: Serializer<
+  ContestLog[]
+> = createCollectionSerializer(contestLogMapper)

--- a/src/app/ranking/transform/ranking-registration.ts
+++ b/src/app/ranking/transform/ranking-registration.ts
@@ -1,7 +1,7 @@
 import { RankingRegistration, RawRankingRegistration } from './../interfaces'
-import { Mapper } from '../../interfaces'
+import { Mapper, MappersWithOptional } from '../../interfaces'
 import { Serializer } from '../../cache'
-import { withOptional } from '../../transform'
+import { createSerializer, withOptional } from '../../transform'
 
 const rawToRankingRegistrationMapper: Mapper<
   RawRankingRegistration,
@@ -23,18 +23,14 @@ const rankingRegistrationToRawMapper: Mapper<
   end: registration.end.toISOString(),
 })
 
-export const rankingRegistrationSerializer: Serializer<RankingRegistration> = {
-  serialize: data => {
-    const raw = rankingRegistrationToRawMapper(data)
-    return JSON.stringify(raw)
-  },
-  deserialize: serializedData => {
-    let raw = JSON.parse(serializedData)
-    return rawToRankingRegistrationMapper(raw)
-  },
-}
-
-export const rankingRegistrationMapper = withOptional({
+export const rankingRegistrationMapper: MappersWithOptional<
+  RawRankingRegistration,
+  RankingRegistration
+> = withOptional({
   toRaw: rankingRegistrationToRawMapper,
   fromRaw: rawToRankingRegistrationMapper,
 })
+
+export const rankingRegistrationSerializer: Serializer<RankingRegistration> = createSerializer(
+  rankingRegistrationMapper,
+)

--- a/src/app/ranking/transform/ranking-registration.ts
+++ b/src/app/ranking/transform/ranking-registration.ts
@@ -1,7 +1,7 @@
 import { RankingRegistration, RawRankingRegistration } from './../interfaces'
-import { Mapper, MappersWithOptional } from '../../interfaces'
+import { Mapper, Mappers } from '../../interfaces'
 import { Serializer } from '../../cache'
-import { createSerializer, withOptional } from '../../transform'
+import { createSerializer, createMappers } from '../../transform'
 
 const rawToRankingRegistrationMapper: Mapper<
   RawRankingRegistration,
@@ -23,10 +23,10 @@ const rankingRegistrationToRawMapper: Mapper<
   end: registration.end.toISOString(),
 })
 
-export const rankingRegistrationMapper: MappersWithOptional<
+export const rankingRegistrationMapper: Mappers<
   RawRankingRegistration,
   RankingRegistration
-> = withOptional({
+> = createMappers({
   toRaw: rankingRegistrationToRawMapper,
   fromRaw: rawToRankingRegistrationMapper,
 })

--- a/src/app/ranking/transform/ranking-registration.ts
+++ b/src/app/ranking/transform/ranking-registration.ts
@@ -3,7 +3,7 @@ import { Mapper } from '../../interfaces'
 import { Serializer } from '../../cache'
 import { withOptional } from '../../transform'
 
-const RawToRankingRegistrationMapper: Mapper<
+const rawToRankingRegistrationMapper: Mapper<
   RawRankingRegistration,
   RankingRegistration
 > = raw => ({
@@ -13,7 +13,7 @@ const RawToRankingRegistrationMapper: Mapper<
   end: new Date(raw.end),
 })
 
-const RankingRegistrationToRawMapper: Mapper<
+const rankingRegistrationToRawMapper: Mapper<
   RankingRegistration,
   RawRankingRegistration
 > = registration => ({
@@ -23,18 +23,18 @@ const RankingRegistrationToRawMapper: Mapper<
   end: registration.end.toISOString(),
 })
 
-export const RankingRegistrationSerializer: Serializer<RankingRegistration> = {
+export const rankingRegistrationSerializer: Serializer<RankingRegistration> = {
   serialize: data => {
-    const raw = RankingRegistrationToRawMapper(data)
+    const raw = rankingRegistrationToRawMapper(data)
     return JSON.stringify(raw)
   },
   deserialize: serializedData => {
     let raw = JSON.parse(serializedData)
-    return RawToRankingRegistrationMapper(raw)
+    return rawToRankingRegistrationMapper(raw)
   },
 }
 
-export const RankingRegistrationMapper = withOptional({
-  toRaw: RankingRegistrationToRawMapper,
-  fromRaw: RawToRankingRegistrationMapper,
+export const rankingRegistrationMapper = withOptional({
+  toRaw: rankingRegistrationToRawMapper,
+  fromRaw: rawToRankingRegistrationMapper,
 })

--- a/src/app/ranking/transform/ranking.ts
+++ b/src/app/ranking/transform/ranking.ts
@@ -24,6 +24,6 @@ export const rankingMapper: Mappers<RawRanking, Ranking> = createMappers({
   fromRaw: rawToRankingMapper,
 })
 
-export const rankingsSerializer: Serializer<
+export const rankingCollectionSerializer: Serializer<
   Ranking[]
 > = createCollectionSerializer(rankingMapper)

--- a/src/app/ranking/transform/ranking.ts
+++ b/src/app/ranking/transform/ranking.ts
@@ -1,5 +1,5 @@
 import { Ranking, RawRanking } from './../interfaces'
-import { Mapper } from '../../interfaces'
+import { Mapper, Mappers } from '../../interfaces'
 import { Serializer } from '../../cache'
 
 const rawToRankingMapper: Mapper<RawRanking, Ranking> = raw => ({
@@ -29,7 +29,7 @@ export const rankingsSerializer: Serializer<Ranking[]> = {
   },
 }
 
-export const rankingMapper = {
+export const rankingMapper: Mappers<RawRanking, Ranking> = {
   toRaw: rankingToRawMapper,
   fromRaw: rawToRankingMapper,
 }

--- a/src/app/ranking/transform/ranking.ts
+++ b/src/app/ranking/transform/ranking.ts
@@ -1,7 +1,7 @@
 import { Ranking, RawRanking } from './../interfaces'
 import { Mapper, Mappers } from '../../interfaces'
 import { Serializer } from '../../cache'
-import { createMappers } from '../../transform'
+import { createMappers, createCollectionSerializer } from '../../transform'
 
 const rawToRankingMapper: Mapper<RawRanking, Ranking> = raw => ({
   contestId: raw.contest_id,
@@ -19,18 +19,11 @@ const rankingToRawMapper: Mapper<Ranking, RawRanking> = ranking => ({
   amount: ranking.amount,
 })
 
-export const rankingsSerializer: Serializer<Ranking[]> = {
-  serialize: data => {
-    const raw = data.map(rankingToRawMapper)
-    return JSON.stringify(raw)
-  },
-  deserialize: serializedData => {
-    let raw = JSON.parse(serializedData)
-    return raw.map(rawToRankingMapper)
-  },
-}
-
 export const rankingMapper: Mappers<RawRanking, Ranking> = createMappers({
   toRaw: rankingToRawMapper,
   fromRaw: rawToRankingMapper,
 })
+
+export const rankingsSerializer: Serializer<
+  Ranking[]
+> = createCollectionSerializer(rankingMapper)

--- a/src/app/ranking/transform/ranking.ts
+++ b/src/app/ranking/transform/ranking.ts
@@ -2,7 +2,7 @@ import { Ranking, RawRanking } from './../interfaces'
 import { Mapper } from '../../interfaces'
 import { Serializer } from '../../cache'
 
-const RawToRankingMapper: Mapper<RawRanking, Ranking> = raw => ({
+const rawToRankingMapper: Mapper<RawRanking, Ranking> = raw => ({
   contestId: raw.contest_id,
   userId: raw.user_id,
   userDisplayName: raw.user_display_name,
@@ -10,7 +10,7 @@ const RawToRankingMapper: Mapper<RawRanking, Ranking> = raw => ({
   amount: raw.amount,
 })
 
-const RankingToRawMapper: Mapper<Ranking, RawRanking> = ranking => ({
+const rankingToRawMapper: Mapper<Ranking, RawRanking> = ranking => ({
   contest_id: ranking.contestId,
   user_id: ranking.userId,
   user_display_name: ranking.userDisplayName,
@@ -18,18 +18,18 @@ const RankingToRawMapper: Mapper<Ranking, RawRanking> = ranking => ({
   amount: ranking.amount,
 })
 
-export const RankingsSerializer: Serializer<Ranking[]> = {
+export const rankingsSerializer: Serializer<Ranking[]> = {
   serialize: data => {
-    const raw = data.map(RankingToRawMapper)
+    const raw = data.map(rankingToRawMapper)
     return JSON.stringify(raw)
   },
   deserialize: serializedData => {
     let raw = JSON.parse(serializedData)
-    return raw.map(RawToRankingMapper)
+    return raw.map(rawToRankingMapper)
   },
 }
 
-export const RankingMapper = {
-  toRaw: RankingToRawMapper,
-  fromRaw: RawToRankingMapper,
+export const rankingMapper = {
+  toRaw: rankingToRawMapper,
+  fromRaw: rawToRankingMapper,
 }

--- a/src/app/ranking/transform/ranking.ts
+++ b/src/app/ranking/transform/ranking.ts
@@ -1,6 +1,7 @@
 import { Ranking, RawRanking } from './../interfaces'
 import { Mapper, Mappers } from '../../interfaces'
 import { Serializer } from '../../cache'
+import { createMappers } from '../../transform'
 
 const rawToRankingMapper: Mapper<RawRanking, Ranking> = raw => ({
   contestId: raw.contest_id,
@@ -29,7 +30,7 @@ export const rankingsSerializer: Serializer<Ranking[]> = {
   },
 }
 
-export const rankingMapper: Mappers<RawRanking, Ranking> = {
+export const rankingMapper: Mappers<RawRanking, Ranking> = createMappers({
   toRaw: rankingToRawMapper,
   fromRaw: rawToRankingMapper,
-}
+})

--- a/src/app/transform.spec.ts
+++ b/src/app/transform.spec.ts
@@ -1,0 +1,74 @@
+import {
+  createMappers,
+  createSerializer,
+  createCollectionSerializer,
+  optionalizeSerializer,
+} from './transform'
+
+interface Raw {
+  a: string
+  b: string
+}
+
+interface Target {
+  a: string
+  b: Date
+}
+
+const toRaw = (target: Target): Raw => ({
+  a: target.a,
+  b: target.b.toISOString(),
+})
+
+const fromRaw = (raw: Raw): Target => ({
+  a: raw.a,
+  b: new Date(raw.b),
+})
+
+describe('createMappers', () => {
+  it('should be able to map between raw/target back and forth', () => {
+    const mappers = createMappers({ toRaw, fromRaw })
+    const raw = { a: 'foobar', b: '2020-04-27T04:53:54.893Z' }
+    expect(mappers.toRaw(mappers.fromRaw(raw))).toMatchObject(raw)
+  })
+})
+
+describe('createSerializer', () => {
+  it('should be able to serialize and deserialize back and forth', () => {
+    const mappers = createMappers({ toRaw, fromRaw })
+    const serializer = createSerializer(mappers)
+    const target = { a: 'foobar', b: new Date() }
+    expect(serializer.deserialize(serializer.serialize(target))).toMatchObject(
+      target,
+    )
+  })
+})
+
+describe('createCollectionSerializer', () => {
+  it('should be able to serialize and deserialize a collection back and forth', () => {
+    const mappers = createMappers({ toRaw, fromRaw })
+    const serializer = createCollectionSerializer(mappers)
+    const target = [
+      { a: 'foo', b: new Date() },
+      { a: 'bar', b: new Date() },
+    ]
+    expect(serializer.deserialize(serializer.serialize(target))).toMatchObject(
+      target,
+    )
+  })
+})
+
+describe('optionalizeSerializer', () => {
+  it('should be able to handle undefined values correctly', () => {
+    const mappers = createMappers({ toRaw, fromRaw })
+    const serializer = optionalizeSerializer(createSerializer(mappers))
+    const target = { a: 'foobar', b: new Date() }
+
+    expect(serializer.deserialize(serializer.serialize(target))).toMatchObject(
+      target,
+    )
+    expect(serializer.deserialize(serializer.serialize(undefined))).toEqual(
+      undefined,
+    )
+  })
+})

--- a/src/app/transform.ts
+++ b/src/app/transform.ts
@@ -1,25 +1,6 @@
 import { Serializer } from './cache'
 import { Mappers } from './interfaces'
 
-export const optionalizeSerializer = <DataType>(
-  serializer: Serializer<DataType>,
-): Serializer<DataType | undefined> => ({
-  serialize: data => {
-    if (!data) {
-      return ''
-    }
-
-    return serializer.serialize(data)
-  },
-  deserialize: serializedData => {
-    if (serializedData === '') {
-      return undefined
-    }
-
-    return serializer.deserialize(serializedData)
-  },
-})
-
 export const createMappers = <Raw, Original>({
   toRaw,
   fromRaw,
@@ -66,3 +47,22 @@ export function createCollectionSerializer<Raw, Target>(
     },
   }
 }
+
+export const optionalizeSerializer = <DataType>(
+  serializer: Serializer<DataType>,
+): Serializer<DataType | undefined> => ({
+  serialize: data => {
+    if (!data) {
+      return ''
+    }
+
+    return serializer.serialize(data)
+  },
+  deserialize: serializedData => {
+    if (serializedData === '') {
+      return undefined
+    }
+
+    return serializer.deserialize(serializedData)
+  },
+})

--- a/src/app/transform.ts
+++ b/src/app/transform.ts
@@ -1,5 +1,5 @@
 import { Serializer } from './cache'
-import { Mappers, MappersWithOptional } from './interfaces'
+import { Mappers } from './interfaces'
 
 export const optionalizeSerializer = <DataType>(
   serializer: Serializer<DataType>,
@@ -20,15 +20,20 @@ export const optionalizeSerializer = <DataType>(
   },
 })
 
-export const withOptional = <Raw, Original>(
-  mappers: Mappers<Raw, Original>,
-): MappersWithOptional<Raw, Original> => ({
-  ...mappers,
+export const createMappers = <Raw, Original>({
+  toRaw,
+  fromRaw,
+}: {
+  toRaw: (original: Original) => Raw
+  fromRaw: (raw: Raw) => Original
+}): Mappers<Raw, Original> => ({
+  toRaw,
+  fromRaw,
   optional: {
     toRaw: (original: Original | undefined): Raw | undefined =>
-      original ? mappers.toRaw(original) : undefined,
+      original ? toRaw(original) : undefined,
     fromRaw: (raw: Raw | undefined): Original | undefined =>
-      raw ? mappers.fromRaw(raw) : undefined,
+      raw ? fromRaw(raw) : undefined,
   },
 })
 

--- a/src/app/transform.ts
+++ b/src/app/transform.ts
@@ -1,7 +1,7 @@
 import { Serializer } from './cache'
 import { Mappers, MappersWithOptional } from './interfaces'
 
-export const OptionalizeSerializer = <DataType>(
+export const optionalizeSerializer = <DataType>(
   serializer: Serializer<DataType>,
 ): Serializer<DataType | undefined> => ({
   serialize: data => {

--- a/src/app/transform.ts
+++ b/src/app/transform.ts
@@ -51,3 +51,18 @@ export function createSerializer<Raw, Target>(
     },
   }
 }
+
+export function createCollectionSerializer<Raw, Target>(
+  mapper: Mappers<Raw, Target>,
+): Serializer<Target[]> {
+  return {
+    serialize: data => {
+      const raw = data.map(mapper.toRaw)
+      return JSON.stringify(raw)
+    },
+    deserialize: data => {
+      let raw = JSON.parse(data)
+      return raw.map(mapper.fromRaw)
+    },
+  }
+}

--- a/src/app/transform.ts
+++ b/src/app/transform.ts
@@ -31,3 +31,18 @@ export const withOptional = <Raw, Original>(
       raw ? mappers.fromRaw(raw) : undefined,
   },
 })
+
+export function createSerializer<Raw, Target>(
+  mapper: Mappers<Raw, Target>,
+): Serializer<Target> {
+  return {
+    serialize: data => {
+      const raw = mapper.toRaw(data)
+      return JSON.stringify(raw)
+    },
+    deserialize: data => {
+      let raw = JSON.parse(data)
+      return mapper.fromRaw(raw)
+    },
+  }
+}

--- a/src/app/ui/components/Layout.tsx
+++ b/src/app/ui/components/Layout.tsx
@@ -109,6 +109,7 @@ const StickyFooterContainer = styled.div`
   overflow: hidden;
   position: relative;
   box-sizing: border-box;
+  top: -10px;
 
   ${media.greaterThan('medium')`
     padding-bottom: 250px;

--- a/src/app/ui/components/Layout.tsx
+++ b/src/app/ui/components/Layout.tsx
@@ -8,7 +8,7 @@ import Constants from '../Constants'
 import Footer from './Footer'
 import ActivityIndicator from './ActivityIndicator'
 import { RootState } from '../../store'
-import { ContestMapper } from '../../contest/transform'
+import { contestMapper } from '../../contest/transform'
 
 interface Props {
   overridesLayout: boolean
@@ -17,7 +17,7 @@ interface Props {
 const Layout: React.SFC<Props> = ({ children, overridesLayout }) => {
   const isLoading = useSelector((state: RootState) => state.app.isLoading)
   const contests = useSelector((state: RootState) =>
-    state.contest.recentContests.map(ContestMapper.fromRaw),
+    state.contest.recentContests.map(contestMapper.fromRaw),
   )
 
   if (overridesLayout) {

--- a/src/app/ui/components/navigation/NavigationBar.tsx
+++ b/src/app/ui/components/navigation/NavigationBar.tsx
@@ -9,7 +9,7 @@ import { ActiveUserNavigationBar } from './ActiveUserNavigationBar'
 import { AnonymousNavigationBar } from './AnonymousNavigationBar'
 import { runEffects as sessionRunEffects } from '../../../session/redux'
 import { runEffects as rankingRunEffects } from '../../../ranking/redux'
-import { RankingRegistrationMapper } from '../../../ranking/transform/ranking-registration'
+import { rankingRegistrationMapper } from '../../../ranking/transform/ranking-registration'
 import LinkContainer from './LinkContainer'
 import Link from 'next/link'
 import { ButtonLink } from '..'
@@ -69,7 +69,7 @@ const NavigationBar = ({
 
 const mapStateToProps = (state: RootState) => ({
   user: state.session.user,
-  registration: RankingRegistrationMapper.optional.fromRaw(
+  registration: rankingRegistrationMapper.optional.fromRaw(
     state.ranking.rawRegistration,
   ),
 })

--- a/src/pages/contests/[contest_id]/ranking.tsx
+++ b/src/pages/contests/[contest_id]/ranking.tsx
@@ -7,16 +7,16 @@ import { useSelector, useDispatch } from 'react-redux'
 import { RootState } from '../../../app/store'
 import RankingOverview from '../../../app/ranking/pages/RankingOverview'
 import { runEffects } from '../../../app/ranking/redux'
-import { ContestSerializer } from '../../../app/contest/transform'
-import { RankingRegistrationMapper } from '../../../app/ranking/transform/ranking-registration'
+import { contestSerializer } from '../../../app/contest/transform'
+import { rankingRegistrationMapper } from '../../../app/ranking/transform/ranking-registration'
 import { useCachedApiState, isReady } from '../../../app/cache'
 import ContestApi from '../../../app/contest/api'
-import { OptionalizeSerializer } from '../../../app/transform'
+import { optionalizeSerializer } from '../../../app/transform'
 import { Contest } from '../../../app/contest/interfaces'
 
 export default () => {
   const registration = useSelector((state: RootState) =>
-    RankingRegistrationMapper.optional.fromRaw(state.ranking.rawRegistration),
+    rankingRegistrationMapper.optional.fromRaw(state.ranking.rawRegistration),
   )
   const user = useSelector((state: RootState) => state.session.user)
   const effectCount = useSelector(
@@ -38,7 +38,7 @@ export default () => {
       return ContestApi.get(contestId)
     },
     dependencies: [contestId],
-    serializer: OptionalizeSerializer(ContestSerializer),
+    serializer: optionalizeSerializer(contestSerializer),
   })
 
   if (!contestId) {

--- a/src/pages/ranking.tsx
+++ b/src/pages/ranking.tsx
@@ -7,12 +7,12 @@ import { runEffects } from '../app/ranking/redux'
 import { RawContest } from '../app/contest/interfaces'
 import { RankingRegistration } from '../app/ranking/interfaces'
 import { User } from '../app/session/interfaces'
-import { ContestMapper } from '../app/contest/transform'
-import { RankingRegistrationMapper } from '../app/ranking/transform/ranking-registration'
+import { contestMapper } from '../app/contest/transform'
+import { rankingRegistrationMapper } from '../app/ranking/transform/ranking-registration'
 
 const mapStateToProps = (state: RootState) => ({
   rawContest: state.contest.latestContest,
-  registration: RankingRegistrationMapper.optional.fromRaw(
+  registration: rankingRegistrationMapper.optional.fromRaw(
     state.ranking.rawRegistration,
   ),
   user: state.session.user,
@@ -39,7 +39,7 @@ export default connect(
     return null
   }
 
-  const contest = ContestMapper.fromRaw(rawContest)
+  const contest = contestMapper.fromRaw(rawContest)
 
   return (
     <>


### PR DESCRIPTION
## Why

There was a lot of duplication to transform between raw and domain objects and their associated serializers.

## What

Make these functions generic and have tests for these so we're less likely to have things break. Individual mapper functions should also be tested, this will be taken care of in a follow up.