### PR TITLE
Fix input styles on ios

### DIFF
--- a/src/app/ui/components/Form.tsx
+++ b/src/app/ui/components/Form.tsx
@@ -184,8 +184,12 @@ const StyledSelect = styled.select`
 `
 
 export const Input = styled.input`
+  -moz-appearance: none;
+  -webkit-appearance: none;
+  appearance: none;
   border: 1px solid rgba(0, 0, 0, 0.12);
   border-bottom-width: 3px;
+  border-radius: 0;
   background: ${Constants.colors.light};
   padding: 4px 12px;
   font-size: 1.1em;


### PR DESCRIPTION
## Why

Inputs looked kinda odd because of the default styles that weren't overwritten.