### PR TITLE
Change pre-commit hook to pre-push

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "yarn run test && yarn run lint"
+      "pre-push": "yarn run test && yarn run lint"
     }
   },
   "dependencies": {


### PR DESCRIPTION
## Why

The pre-commit hook is a bit too slow to run on every commit, it impacts developer experience.

## What

* Change pre-commit hook to pre-push, this should still allow for corrections to happen before being pushed to remote