### PR TITLE
fix full-screen login modal

### DIFF
--- a/src/app/landing/components/SignupCard.tsx
+++ b/src/app/landing/components/SignupCard.tsx
@@ -72,7 +72,7 @@ const Card = styled.div`
     right: 0;
     z-index: 100;
 
-    @media screen and (max-height: 700px) {
+    @media screen and (max-height: 700px) and (min-width: 1171px) {
       & {
         top: 0;
         position: absolute;


### PR DESCRIPTION
## What

The login modal would expand to full width of the screen when the height
is also less than 700px. This is a side effect of making sure the modal
fits on screen when it scrolls along, which is not happening for lower
resolutions.