### PR TITLE
Fix reading activity graph for utc+x timezones

### DIFF
--- a/jest-global-setup.js
+++ b/jest-global-setup.js
@@ -1,0 +1,3 @@
+module.exports = async () => {
+  process.env.TZ = 'UTC'
+}

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
   "jest": {
     "moduleNameMapper": {
       "@app/(.*)": "<rootDir>/src/app/$1"
-    }
+    },
+    "globalSetup": "./jest-global-setup.js"
   }
 }

--- a/src/app/dates.ts
+++ b/src/app/dates.ts
@@ -6,6 +6,10 @@ export function prettyDateInUTC(date: Date): string {
   return format(utcToZonedTime(date, 'utc'), 'uuuu-MM-dd', { timeZone: 'UTC' })
 }
 
+export function prettyDateIgnoreTimezone(date: Date): string {
+  return format(date, 'uuuu-MM-dd')
+}
+
 export function formatUTC(date: Date, pattern: string): string {
   return format(utcToZonedTime(date, 'utc'), pattern, { timeZone: 'UTC' })
 }
@@ -13,7 +17,7 @@ export function formatUTC(date: Date, pattern: string): string {
 export function getDates(startDate: Date, endDate: Date) {
   const dates = []
 
-  let currentDate = utcToZonedTime(startDate, 'utc')
+  let currentDate = utcToZonedTime(startDate, 'UTC')
   const deadline = utcToZonedTime(endDate, 'UTC')
 
   while (currentDate < deadline) {

--- a/src/app/ranking/transform/graph.spec.ts
+++ b/src/app/ranking/transform/graph.spec.ts
@@ -1,5 +1,11 @@
 import { aggregateReadingActivity, aggregateMediaDistribution } from './graph'
 
+describe('timezone', () => {
+  it('should always be UTC', () => {
+    expect(new Date().getTimezoneOffset()).toBe(0)
+  })
+})
+
 describe('aggregateReadingActivity', () => {
   it('should aggregate correctly', () => {
     const contest = {

--- a/src/app/ranking/transform/graph.ts
+++ b/src/app/ranking/transform/graph.ts
@@ -3,7 +3,7 @@ import { ContestLog, Ranking, RankingRegistrationOverview } from '../interfaces'
 import { Contest } from '@app/contest/interfaces'
 import { formatLanguageName, formatMediaDescription } from '../transform/format'
 import { graphColor } from '@app/ui/components/Graphs'
-import { getDates, prettyDateInUTC } from '@app/dates'
+import { getDates, prettyDateIgnoreTimezone, prettyDateInUTC } from '@app/dates'
 
 // Graph aggregators
 
@@ -52,7 +52,7 @@ export const aggregateReadingActivity = (
   } = {}
 
   getDates(contest.start, contest.end).forEach(date => {
-    initializedSeries[prettyDateInUTC(date)] = {
+    initializedSeries[prettyDateIgnoreTimezone(date)] = {
       x: date.toISOString(),
       y: 0,
       language: '',


### PR DESCRIPTION
## Why

In any timezone that's UTC + anything the reading graph will be offset by a day.